### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/M2MServicesDevOps/9ef47e27-5d97-4d22-bfd5-689a7b5cbbdc/c47b4fa9-2a89-446f-9de3-df7c6337179e/_apis/work/boardbadge/572d8f54-ad2f-4a27-9c2d-7f8c9c3dab67)](https://dev.azure.com/M2MServicesDevOps/9ef47e27-5d97-4d22-bfd5-689a7b5cbbdc/_boards/board/t/c47b4fa9-2a89-446f-9de3-df7c6337179e/Microsoft.RequirementCategory)
 # Your GitHub Learning Lab Repository for Introducing GitHub
 
 Welcome to **your** repository for your GitHub Learning Lab course. This repository will be used during the different activities that I will be guiding you through. See a word you don't understand? We've included an emoji 📖 next to some key terms. Click on it to see its definition.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/M2MServicesDevOps/9ef47e27-5d97-4d22-bfd5-689a7b5cbbdc/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.